### PR TITLE
fix: Not bundle if Handlebars expression is included in the asset path

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,4 @@
-module.exports = bundler => {
-  bundler.addAssetType(
-    "hbs",
-    require.resolve("parcel-bundler/src/assets/HTMLAsset")
-  );
-  bundler.addAssetType(
-    "handlebars",
-    require.resolve("parcel-bundler/src/assets/HTMLAsset")
-  );
+module.exports = (bundler) => {
+  bundler.addAssetType("hbs", require.resolve("./src/HbsAsset"));
+  bundler.addAssetType("handlebars", require.resolve("./src/HbsAsset"));
 };

--- a/src/HbsAsset.js
+++ b/src/HbsAsset.js
@@ -1,0 +1,20 @@
+const HTMLAsset = require("parcel-bundler/lib/assets/HTMLAsset");
+
+const handlebarsExpression = (path) => {
+  return /{{.+}}/.test(path);
+};
+
+class HbsAsset extends HTMLAsset {
+  addDependency(name, options) {
+    if (!handlebarsExpression(opts.resolved))
+      return super.addDependency(name, options);
+  }
+
+  processSingleDependency(path, options) {
+    return handlebarsExpression(path)
+      ? path
+      : super.processSingleDependency(path, options);
+  }
+}
+
+module.exports = HbsAsset;

--- a/src/HbsAsset.js
+++ b/src/HbsAsset.js
@@ -1,7 +1,7 @@
 const HTMLAsset = require("parcel-bundler/lib/assets/HTMLAsset");
 
 const handlebarsExpression = (path) => {
-  return /^{{.+?}}$/.test(path);
+  return /{{.+?}}/.test(path);
 };
 
 class HbsAsset extends HTMLAsset {

--- a/src/HbsAsset.js
+++ b/src/HbsAsset.js
@@ -1,7 +1,7 @@
 const HTMLAsset = require("parcel-bundler/lib/assets/HTMLAsset");
 
 const handlebarsExpression = (path) => {
-  return /{{.+}}/.test(path);
+  return /^{{.+?}}$/.test(path);
 };
 
 class HbsAsset extends HTMLAsset {

--- a/src/HbsAsset.js
+++ b/src/HbsAsset.js
@@ -6,7 +6,7 @@ const handlebarsExpression = (path) => {
 
 class HbsAsset extends HTMLAsset {
   addDependency(name, options) {
-    if (!handlebarsExpression(opts.resolved))
+    if (!handlebarsExpression(options.resolved))
       return super.addDependency(name, options);
   }
 


### PR DESCRIPTION
Hello.

Handlebars expressions can be used anywhere in the template but it will fail to bundle if you use it in href or src.
So I fixed don't bundle when the asset path contains a Handlebars expression.

This idea was suggested in https://github.com/parcel-bundler/parcel/issues/1186#issuecomment-453468414 .
